### PR TITLE
Fixed typo in header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,7 @@
 	<meta name="og:type" content="article">
 	<!-- Open Graph - Article -->
 	<meta name="article:tag" content="{{ range .Params.tags }}{{.}} {{end}}">
-	<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/style{{ $.Site.Params.style }}.css">
+	<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/style{{ $.Site.Params.style }}.css">
 	<!-- Google Analytics -->
 	{{ template "_internal/google_analytics_async.html" . }}
 	<!-- highlight.js -->


### PR DESCRIPTION
Fixed typo in header.html that caused a broken stylesheet link